### PR TITLE
Fix crash on duplicate columns in modifyTables via pcall

### DIFF
--- a/koreader-settings-folder/extensions/xraymodel/xraydatasaver.lua
+++ b/koreader-settings-folder/extensions/xraymodel/xraydatasaver.lua
@@ -828,7 +828,9 @@ function XrayDataSaver.modifyTables(conn, update_tasks_count, version_index)
     for i = version_index + 1, update_tasks_count do
         if self.scheme_alter_queries[i] then
             sql = self.scheme_alter_queries[i]
-            conn:exec(sql)
+            pcall(function()
+                conn:exec(sql)
+            end)
         end
     end
 end


### PR DESCRIPTION
## Description
This PR fixes a critical startup crash where KOReader fails to apply patches (`2-xray-patches.lua`) due to database migration conflicts in `XrayDataSaver.modifyTables`.

## Context / Problem
When the `version_index` gets out of sync on certain devices, the plugin attempts to re-run schema alteration queries (such as adding `tags` or `stars` columns) that already exist in the local SQLite database. This causes `conn:exec(sql)` to throw a fatal SQLite duplicate column error, preventing the plugin and user patches from loading entirely.

## Solution
Wrapped the migration query execution inside a `pcall` block. This ensures that if a column modification has already been applied, the error is safely caught and ignored, allowing the plugin to finish initializing successfully without breaking the boot sequence.